### PR TITLE
fix: dispatch web UI requests via server.extensions.request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.1] - 2026-04-07
+
+### Fixed
+- **Web UI (`/polar-cloud/`) was completely broken** since the WebSocket
+  JSON-RPC migration, showing "Not Found" / loading errors on every call.
+  Three interacting bugs caused this:
+  - The agent's `_on_message` treated any JSON-RPC frame with an `id` as
+    a response, silently dropping every incoming request from the web UI.
+  - Handler return values were discarded, so even if dispatch had worked
+    Moonraker's `call_method_with_response` would have hung until the
+    websocket dropped.
+  - The web UI posted to `/printer/jsonrpc` (which doesn't exist) using
+    bare method names. Agent methods must be invoked via Moonraker's
+    `server.extensions.request` wrapper.
+- The web page now correctly reflects real-time service / connection /
+  registration status on first load and across refreshes.
+
+### Changed
+- Agent no longer calls `connection.register_remote_method` on Moonraker
+  for frontend handler registration. That endpoint registered methods as
+  Klippy-bridged one-way calls — the wrong contract for request/response.
+  Pre-registration isn't required for `server.extensions.request`;
+  Moonraker forwards arbitrary method names to the agent's WebSocket
+  connection. Startup is slightly faster and quieter as a result.
+
+### Technical Notes
+- `_on_message` now correctly distinguishes JSON-RPC requests, responses,
+  and notifications and replies to requests with proper `result` /
+  `error` envelopes (`-32601` for unknown method, `-32000` for handler
+  exceptions).
+- Both `_on_message` and `register_remote_method` now have docstrings
+  explaining the protocol contract so this doesn't drift again.
+- Verified end-to-end on Creality K1C with Moonraker v0.9.3-128. Fix is
+  in shared code with no printer-specific assumptions; safe for all
+  supported printer types.
+
 ## [1.2.0] - 2025-12-02
 
 ### Added

--- a/src/polar_cloud.py
+++ b/src/polar_cloud.py
@@ -203,18 +203,34 @@ class MoonrakerConnection:
         threading.Thread(target=self._initialize_connection, daemon=True).start()
 
     def _on_message(self, ws, message):
-        """Handle incoming WebSocket message."""
+        """Handle incoming WebSocket message.
+
+        A WebSocket message from Moonraker is one of three JSON-RPC shapes:
+
+          * Response: has ``id`` and (``result`` or ``error``); no ``method``.
+            Pop the matching callback we recorded when the outbound request was
+            sent.
+          * Request: has both ``id`` and ``method``. The peer (typically a
+            web client invoking us via ``server.extensions.request``) expects
+            a JSON-RPC reply with the same ``id``.
+          * Notification: has ``method`` but no ``id``. Fire-and-forget; used
+            by Moonraker for ``notify_*`` events.
+
+        Note that the legacy logic of "any message with an id is a response"
+        is wrong: requests carry an id too, and treating them as responses
+        silently swallowed every frontend invocation.
+        """
         try:
             data = json.loads(message)
 
-            # Handle JSON-RPC response (has 'id' field)
-            if 'id' in data:
-                callback = None
-                with self.request_callbacks_lock:
-                    req_id = data['id']
-                    if req_id in self.request_callbacks:
-                        callback = self.request_callbacks.pop(req_id)
+            req_id = data.get('id')
+            method = data.get('method')
+            params = data.get('params', {})
 
+            # JSON-RPC response: id present, no method.
+            if req_id is not None and method is None:
+                with self.request_callbacks_lock:
+                    callback = self.request_callbacks.pop(req_id, None)
                 if callback:
                     try:
                         callback(data)
@@ -222,9 +238,32 @@ class MoonrakerConnection:
                         logger.error(f"Error in request callback: {e}")
                 return
 
-            # Handle JSON-RPC notification (has 'method' field, no 'id')
-            method = data.get('method', '')
-            params = data.get('params', {})
+            # JSON-RPC request: id and method both present. The caller wants
+            # a response, so dispatch a handler and reply with the same id.
+            if req_id is not None and method is not None:
+                handler = self.remote_method_handlers.get(method)
+                if handler is None:
+                    self._send_response(req_id, error={
+                        'code': -32601,
+                        'message': f"Method not found: {method}"
+                    })
+                    return
+                try:
+                    result = handler(params)
+                except Exception as e:
+                    logger.exception(f"Error in remote method handler {method}")
+                    self._send_response(req_id, error={
+                        'code': -32000,
+                        'message': str(e)
+                    })
+                    return
+                self._send_response(req_id, result=result)
+                return
+
+            # JSON-RPC notification path (method present, no id).
+            if method is None:
+                logger.warning(f"Received WebSocket message with neither method nor id: {data}")
+                return
 
             # Handle Moonraker notifications
             if method == 'notify_klippy_ready':
@@ -250,15 +289,6 @@ class MoonrakerConnection:
                         self._merge_status(status)
                     self.on_event('status_update', status)
 
-            elif method in self.remote_method_handlers:
-                # Handle registered remote method calls
-                handler = self.remote_method_handlers[method]
-                try:
-                    result = handler(params)
-                    # Remote methods don't expect responses
-                except Exception as e:
-                    logger.error(f"Error in remote method handler {method}: {e}")
-
             else:
                 # Pass unhandled notifications to event handler
                 self.on_event('notification', {'method': method, 'params': params})
@@ -267,6 +297,24 @@ class MoonrakerConnection:
             logger.error(f"Invalid JSON from Moonraker: {e}")
         except Exception as e:
             logger.error(f"Error handling Moonraker message: {e}")
+
+    def _send_response(self, req_id, result=None, error=None):
+        """Send a JSON-RPC response back over the WebSocket.
+
+        Used to reply to incoming requests dispatched from
+        ``_on_message``. Exactly one of ``result`` / ``error`` should be set;
+        if both are None, an empty result is sent (which is a valid JSON-RPC
+        response).
+        """
+        response = {'jsonrpc': '2.0', 'id': req_id}
+        if error is not None:
+            response['error'] = error
+        else:
+            response['result'] = result
+        try:
+            self.message_queue.put_nowait(response)
+        except queue.Full:
+            logger.warning(f"Moonraker message queue full, dropping response for id {req_id}")
 
     def _on_error(self, ws, error):
         """Handle WebSocket error."""
@@ -417,21 +465,34 @@ class MoonrakerConnection:
             return self.printer_state.copy()
 
     def register_remote_method(self, method_name, handler):
-        """Register a handler for remote method calls."""
+        """Register a handler that incoming JSON-RPC requests can invoke.
+
+        Web clients reach these methods via Moonraker's
+        ``server.extensions.request`` endpoint, e.g.::
+
+            POST /server/jsonrpc
+            {
+              "jsonrpc": "2.0",
+              "method": "server.extensions.request",
+              "params": {"agent": "polar_cloud", "method": <method_name>,
+                         "arguments": <params>},
+              "id": ...
+            }
+
+        Moonraker forwards that to this agent as a JSON-RPC request over the
+        WebSocket; ``_on_message`` dispatches it to the registered handler and
+        replies with the handler's return value (or an error).
+
+        Note: we deliberately do *not* call ``connection.register_remote_method``
+        here. That endpoint registers a method as Klippy-bridged (one-way,
+        Klippy -> agent) via ``klippy_connection.register_method_from_agent``,
+        which is the wrong path for frontend-callable request/response methods.
+        Pre-registration is not required for ``server.extensions.request`` —
+        Moonraker just dispatches whatever method name arrives to the agent's
+        WebSocket connection.
+        """
         self.remote_method_handlers[method_name] = handler
-
-        # Also register with Moonraker
-        def on_register(data):
-            if 'error' in data:
-                logger.error(f"Failed to register remote method {method_name}: {data['error']}")
-            else:
-                logger.info(f"Registered remote method: {method_name}")
-
-        self.send_request(
-            'connection.register_remote_method',
-            params={'method_name': method_name},
-            callback=on_register
-        )
+        logger.info(f"Registered remote method: {method_name}")
 
 
 class PolarCloudService:

--- a/src/polar_cloud_web.html
+++ b/src/polar_cloud_web.html
@@ -433,18 +433,31 @@
     </div>
 
     <script>
-        // Moonraker JSON-RPC endpoint for calling remote methods
-        const JSONRPC_URL = '/printer/jsonrpc';
+        // Moonraker JSON-RPC endpoint. Agent methods are reached by wrapping
+        // the call in `server.extensions.request` (see callRemoteMethod below);
+        // this is the standard Moonraker path for invoking methods on a
+        // connected agent. Bare method names sent to /server/jsonrpc would
+        // return "Method not found" because agent methods are not registered
+        // in Moonraker's top-level RPC namespace.
+        const JSONRPC_URL = '/server/jsonrpc';
+        const POLAR_AGENT_NAME = 'polar_cloud';
 
-        // Helper to call remote methods registered by Polar Cloud agent
+        // Helper to call methods exposed by the Polar Cloud agent.
+        // The browser POSTs `server.extensions.request` to Moonraker, which
+        // forwards `{method, arguments}` to the agent's WebSocket and awaits
+        // the agent's JSON-RPC response.
         async function callRemoteMethod(method, params = {}) {
             const response = await fetch(JSONRPC_URL, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     jsonrpc: '2.0',
-                    method: method,
-                    params: params,
+                    method: 'server.extensions.request',
+                    params: {
+                        agent: POLAR_AGENT_NAME,
+                        method: method,
+                        arguments: params
+                    },
                     id: Date.now()
                 })
             });


### PR DESCRIPTION
The /polar-cloud/ web page errored out on every call (Error: Not Found, all loaders stuck) because of three interacting bugs introduced when the web UI was migrated to WebSocket JSON-RPC. The page never reflected real status, even though the agent itself was healthy and the cloud connection was fine.

Three bugs:

1. _on_message conflated JSON-RPC requests and responses. Any frame with an "id" was treated as a response to an outbound request and silently dropped if no callback matched. JSON-RPC requests carry an id too, so every incoming frontend invocation was swallowed. Now we distinguish:
     - response: id present, no method
     - request:  id and method both present
     - notification: method present, no id

2. Even if dispatch had been reached, registered handler return values  were thrown away ("# Remote methods don't expect responses"). The new
   _send_response helper sends a proper JSON-RPC reply (or a -32601 /
   -32000 error) so Moonraker's call_method_with_response no longer hangs
   until the websocket dies.

3. The web UI POSTed to /printer/jsonrpc, which doesn't exist on Moonraker (the endpoint is /server/jsonrpc), and used the bare method name. Agent methods are reached via the server.extensions.request wrapper with {agent, method, arguments}. callRemoteMethod now wraps every call; the five callsites are unchanged.

Also stop calling connection.register_remote_method on the agent side. That endpoint registers methods as Klippy-bridged one-way calls via klippy_connection.register_method_from_agent — the wrong contract for frontend request/response. Pre-registration is not required for server.extensions.request; Moonraker dispatches whatever method name arrives to the agent's WebSocket connection. Removing the round-trip also makes startup slightly faster and quieter.

Both functions now have docstrings explaining the protocol contract so this doesn't drift again.

Verified end-to-end on a Creality K1C running Moonraker v0.9.3-128:
  - agent identifies, registers all 6 handlers locally on startup
  - POST /server/extensions/request returns the real status payload
  - POST /server/jsonrpc via nginx port 4408 (the actual web UI path)
    returns the same payload wrapped in a JSON-RPC envelope
  - browser /polar-cloud/ page loads real status after hard refresh

Cross-printer safety: changes are entirely in shared code (src/polar_cloud.py, src/polar_cloud_web.html). Grepped the repo for the six extension method names — they're only referenced from the web UI and the agent itself. Nothing in Klippy macros, install scripts, config templates, or printer-specific paths.