### PR TITLE
fix: point GitHub API and identity URLs at Polar3D namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.2] - 2026-04-07
+
+### Fixed
+- **Hourly update check failing with HTTP 404.** The agent's GitHub API
+  call still pointed at the pre-rename namespace
+  (`vanmorris/polar-cloud-klipper`) instead of `Polar3D/polar-cloud-klipper`,
+  so `latest_version` was never populated and the log was noisy with
+  `Failed to check for updates: HTTP 404` once an hour. The
+  `version_info.latest_version` field returned from `polar_cloud_status`
+  is now populated correctly.
+- **Agent identification URL** sent to Moonraker also pointed at the old
+  namespace. Cosmetic, but it surfaced in `/server/extensions/list` and
+  any UI that displays connected agents. Now reports the canonical
+  `Polar3D/polar-cloud-klipper` URL.
+
 ## [1.5.1] - 2026-04-07
 
 ### Fixed

--- a/src/polar_cloud.py
+++ b/src/polar_cloud.py
@@ -373,7 +373,7 @@ class MoonrakerConnection:
             'client_name': 'polar_cloud',
             'version': self.version,
             'type': 'agent',
-            'url': 'https://github.com/vanmorris/polar-cloud-klipper'
+            'url': 'https://github.com/Polar3D/polar-cloud-klipper'
         }
 
         def on_identify(data):
@@ -1377,7 +1377,7 @@ class PolarCloudService:
             self.last_version_check = current_time
 
             response = requests.get(
-                "https://api.github.com/repos/vanmorris/polar-cloud-klipper/releases/latest",
+                "https://api.github.com/repos/Polar3D/polar-cloud-klipper/releases/latest",
                 timeout=10
             )
 


### PR DESCRIPTION
Two stale URLs in src/polar_cloud.py still referenced the pre-rename `vanmorris/polar-cloud-klipper` namespace, left over from when the repo moved to the Polar3D org:

- The hourly update check (line 1381) called api.github.com/repos/vanmorris/polar-cloud-klipper/releases/latest, which 404s. As a result, `latest_version` was never populated, the `version_info.latest_version` field of polar_cloud_status was always null, and `polar_cloud.log` was noisy with "Failed to check for updates: HTTP 404" once per hour. Verified that the corrected URL (Polar3D/polar-cloud-klipper) returns 200 and a real Release object for v1.5.1.

- The agent identification URL (line 376) sent to Moonraker via the identify call also pointed at the old namespace. Cosmetic, but it surfaced in `/server/extensions/list` output and in any UI that displays connected agents.

Both now point at https://github.com/Polar3D/polar-cloud-klipper.